### PR TITLE
Fetch master before cherry-picking

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,10 +154,15 @@ func runBackport(ctx context.Context, prArgs, commitArgs []string, release strin
 	}
 
 	releaseBranch := "release-" + release
-	err = spawn("git", "fetch", "https://github.com/cockroachdb/cockroach.git",
-		"refs/heads/"+releaseBranch)
-	if err != nil {
-		return errors.Wrapf(err, "fetching %q branch", releaseBranch)
+
+	// Order is important here. releaseBranch is fetched last so that we can
+	// check it out below using FETCH_HEAD.
+	for _, branch := range []string{"master", releaseBranch} {
+		err = spawn("git", "fetch", "https://github.com/cockroachdb/cockroach.git",
+			"refs/heads/"+branch)
+		if err != nil {
+			return errors.Wrapf(err, "fetching %q branch", branch)
+		}
 	}
 
 	backportBranch := fmt.Sprintf("backport%s-%s", release, strings.Join(prArgs, "-"))


### PR DESCRIPTION
The PR commits may not be available locally without a `git fetch
master`. This is most common when backporting someone else's PR, but can
also occur when backporting a PR that you made on a different machine.